### PR TITLE
Namespace collision fix

### DIFF
--- a/fallback_storage/__init__.py
+++ b/fallback_storage/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 default_app_config = 'fallback_storage.FallbackStorageConfig'

--- a/fallback_storage/storage.py
+++ b/fallback_storage/storage.py
@@ -96,7 +96,15 @@ class FallbackStorage(Storage):
             # the current 'name' value from the set, and assign the next potential name to the
             # variable 'name' before running the loop again with the new potential name.
             if len(potential_names) > 1:
-                potential_names.remove(name)
+                # In some edge cases it is possible that both backends have files with duplicate
+                # names. This is most likely to have happened when an older version of django
+                # fallback storages was updated to a newer version. In this instance the initial
+                # name passed to the method will not exist in the potential_names set. Therefore,
+                # attempting to remove it will cause a KeyError to be raised and the method will
+                # fail. Check that the original name is in the set before trying to remove it.
+                if name in potential_names:
+                    potential_names.remove(name)
+
                 name = next(iter(potential_names))
                 continue
 

--- a/tests/test_primary_storage_methods.py
+++ b/tests/test_primary_storage_methods.py
@@ -199,3 +199,16 @@ def test_fallback_get_available_name_for_duplicate_file(inmemorystorage, filesys
     backend = get_storage_class()()
 
     assert backend.get_available_name('foo.txt') != 'foo.txt'
+
+
+def test_fallback_get_available_name_for_duplicate_file_names(inmemorystorage, filesystemstorage):
+    inmemorystorage.save('foo.txt', StringIO('test-foo'))
+    filesystemstorage.save('foo.txt', StringIO('test-foo'))
+
+    # sanity check
+    assert inmemorystorage.exists('foo.txt')
+    assert filesystemstorage.exists('foo.txt')
+
+    backend = get_storage_class()()
+
+    assert backend.get_available_name('foo.txt') != 'foo.txt'


### PR DESCRIPTION
![Slow Loris](http://lemur.duke.edu/wordpress/wp-content/uploads/2014/01/IO-moth-eating-frozen-apple-sauce.jpg "Slow Loris")

# Issue

Version 1.0.0 of django-fallback-storages would allow multiple files with the same name to be uploaded to different storage backends.  This issue was resolved with release 1.1.0.  However, whilst using version 1.0.0 of the library we ended up in a position where we do actually have duplicate files across different storage backends.

In this situation the following line of code will fail because each storage backend has suggested a new name for the uploaded file:

https://github.com/pipermerriam/django-fallback-storage/blob/627f60173bb4dbc00205c23eab3494d85c2ba519/fallback_storage/storage.py#L99

# Solution

Simple solution.  Check that the original file name is present in the set before trying to remove it.  This should be safe as we can guarantee that the next checked file name will be one that has been suggested by at least one of the storage backends.

# Notes

This is only likely to affect people who are upgrading from older versions of django-fallback-storages library.  Although there are obviously issues that need addressing when this happens (not the responsibility of this library) I do not believe the get_available_name method should fail when this edge case is encountered.  Please do say if you disagree for one reason or another.  

If you are in agreement with the above, do you think it would be worth adding some extra logging to identify the fact that there are duplicate files across the various backends in use?  If so I'm quite happy to add it to this PR.